### PR TITLE
カスタムフィールド設定画面:トラッカー選択の表示改善

### DIFF
--- a/app/views/custom_fields/_visibility_by_tracker_selector.html.erb
+++ b/app/views/custom_fields/_visibility_by_tracker_selector.html.erb
@@ -1,11 +1,12 @@
-<fieldset class="box" id="custom_field_tracker_ids"><legend><%= toggle_checkboxes_link("#custom_field_tracker_ids input[type=checkbox]") %><%=l(:label_tracker_plural)%></legend>
+
+<fieldset class="box tabular" id="custom_field_tracker_ids"><legend><%= toggle_checkboxes_link("#custom_field_tracker_ids input[type=checkbox]") %><%=l(:label_tracker_plural)%></legend>
   <% tracker_ids = @custom_field.tracker_ids %>
   <% Tracker.sorted.each do |tracker| %>
-    <%= check_box_tag "custom_field[tracker_ids][]",
-                      tracker.id,
-                      tracker_ids.include?(tracker.id),
-                      :id => "custom_field_tracker_ids_#{tracker.id}" %>
-    <label class="no-css" for="custom_field_tracker_ids_<%=tracker.id%>">
+    <label class="floating">
+      <%= check_box_tag "custom_field[tracker_ids][]",
+                        tracker.id,
+                        tracker_ids.include?(tracker.id),
+                        :id => "custom_field_tracker_ids_#{tracker.id}" %>
       <%= tracker.name %>
     </label>
   <% end %>

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -865,6 +865,18 @@ ul.twofa_backup_codes code { font-size: 16px; line-height: 2em }
   width: 270px;
 }
 
+#custom_field_tracker_ids {
+  max-height: 200px;
+  overflow: auto;
+}
+
+.splitcontent .tabular label.floating{
+  font-weight: normal;
+  margin-left: 0px;
+  text-align: left;
+  width: 200px;
+}
+
 label.block {
   display: block;
   width: auto !important;


### PR DESCRIPTION
redmine.orgのチケットURL(feature): https://www.redmine.org/issues/38650
（patch のものはまだ未作成）

## 改善内容
- トラッカーが多い場合、カスタムフィールドの設定画面でトラッカー選択枠が見づらい
　→ プロジェクト設定画面のトラッカー選択タブのように整列させて見やすくしたい。

## 修正点
- HTMLの構造およびCSSの調整を実施しました。
- CSS調整については盛岡さんと相談/確認済み

## イメージ
### 修正前
![image](https://github.com/agileware-jp/redmine-dev-mirror/assets/46949886/f630d949-c617-414e-9dd2-a1c6bc1d633f)

### 修正後
![image](https://github.com/agileware-jp/redmine-dev-mirror/assets/46949886/bdbb4a1b-4677-442b-96f3-fe9cdb23684f)
