### PR TITLE
set-output 廃止に伴う修正

### DIFF
--- a/.github/workflows/create-patch.yml
+++ b/.github/workflows/create-patch.yml
@@ -24,7 +24,7 @@ jobs:
           git commit -m "Patch for `cat .branch-name`"
           PATCH_FILE=`cat .branch-name | sed 's/\//_/g'`.patch                  # Replace forward slash in branch name with _
           git format-patch develop..HEAD --stdout -k > $PATCH_FILE
-          echo "::set-output name=PATCH_FILE::$PATCH_FILE"
+          echo "PATCH_FILE=$PATCH_FILE" >> $GITHUB_OUTPUT
         id: patch-creator
         env:
           AUTHOR_EMAIL: ${{ github.event.head_commit.author.email }}


### PR DESCRIPTION
Actionsにwarningが出ていたのでリンク先の記事に従って修正しました
![image](https://github.com/agileware-jp/redmine-dev-mirror/assets/755853/3ffd8d91-6b63-4428-95a7-53a19a165d19)
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/