### PR TITLE
プロジェクトメンバー追加時、検索するとチェックが外れる（Feature #71439）

### DIFF
--- a/app/views/members/autocomplete.js.erb
+++ b/app/views/members/autocomplete.js.erb
@@ -1,1 +1,4 @@
-$('#principals_for_new_member').html('<%= escape_javascript(render_principals_for_new_members(@project)) %>');
+$('#principals').find('input[type="checkbox"]').closest('label').hide()
+<% principals_for_new_member_ids(@project)&.map do |member| %>
+  $('#principals').find('input[type="checkbox"][value=<%= member.id %>]').closest('label').show()
+<% end %>

--- a/test/functional/members_controller_test.rb
+++ b/test/functional/members_controller_test.rb
@@ -330,6 +330,6 @@ class MembersControllerTest < Redmine::ControllerTest
       :xhr => true
     )
     assert_response :success
-    assert_include 'User Misc', response.body
+    assert ['value=8', 'value=9'].all? { |value| response.body.include?(value) } # These users are defined in the test/fixtures/users.yml file, lines 119-150.
   end
 end


### PR DESCRIPTION
redmine.orgのチケットURL: https://www.redmine.org/issues/xxxx

### story
https://insidemine.agileware.jp/redmine/issues/71439


### 内容
・名前検索後もチェックが外れないように修正

https://github.com/agileware-jp/redmine-dev-mirror/assets/73740965/b24740d9-c8e4-4e31-addf-efdfecd3d21b


~~・選択済みのユーザーを表示する領域を追加~~ **← UIの変更は取り込まれなさそうな気がして、やっぱりやめます**
![スクリーンショット 2024-02-05 12 01 43](https://github.com/agileware-jp/redmine-dev-mirror/assets/73740965/ed5e2ef5-7710-41be-a0cc-0225c9f87812)


