### PR TITLE
フォーム再表示時にグループに属するユーザーにチェックが入らないようにする

### DIFF
--- a/app/helpers/watchers_helper.rb
+++ b/app/helpers/watchers_helper.rb
@@ -74,7 +74,7 @@ module WatchersHelper
 
   def watchers_checkboxes(object, users, checked=nil)
     users.map do |user|
-      c = checked.nil? ? object.watched_by?(user) : checked
+      c = checked.nil? ? object.watcher_user_ids.include?(user.id) : checked
       tag = check_box_tag 'issue[watcher_user_ids][]', user.id, c, :id => nil
       content_tag 'label', "#{tag} #{h(user)}".html_safe,
                   :id => "issue_watcher_user_ids_#{user.id}",

--- a/test/functional/issues_controller_test.rb
+++ b/test/functional/issues_controller_test.rb
@@ -4778,6 +4778,24 @@ class IssuesControllerTest < Redmine::ControllerTest
     assert_select 'input[name=?][value="8"][checked=checked]', 'issue[watcher_user_ids][]'
   end
 
+  def test_post_create_with_failure_should_not_dereference_group_watchers
+    @request.session[:user_id] = 1
+    post(
+      :create,
+      :params => {
+        :project_id => 5,
+        :issue => {
+          :tracker_id => 1,
+          :watcher_user_ids => ['11']
+        }
+      }
+    )
+    assert_response :success
+
+    assert_select 'input[name=?][value="8"][checked=checked]', 'issue[watcher_user_ids][]', 0
+    assert_select 'input[name=?][value="11"][checked=checked]', 'issue[watcher_user_ids][]', 1
+  end
+
   def test_post_create_should_ignore_non_safe_attributes
     @request.session[:user_id] = 2
     assert_nothing_raised do


### PR DESCRIPTION
redmine.orgのチケットURL: https://www.redmine.org/issues/40410
（追記：パッチ送りました https://www.redmine.org/issues/40555 ）

チケット新規作成画面で、送信後バリデーションエラーが発生してフォームが再表示された際に、チェックを入れていない項目にもチェックが入る問題の修正です。
ウォッチャーのチェックボックスが対象で、グループを選択した場合に、グループに属するユーザーにもチェックが入ってしまうという現象です。

現状はチェックを入れるかどうかは `watched_by?` メソッドによって判定されていて、最終的に誰がウォッチするのかという動作は変わらないのですが、フォームの構造的にバリデーションエラーが発生した際は送信したものがそのまま表示されたほうが自然なのではないかと思い対応しました。
単体テストは元チケットに貼られたものを取り込んでいます。